### PR TITLE
Resize images asynchronously

### DIFF
--- a/frog/enhance-body.rkt
+++ b/frog/enhance-body.rkt
@@ -166,6 +166,7 @@
                                 (sizes "(max-width: 2px) 100vw, 2px")
                                 (alt "")))
                           (p ((class "caption")) "some text"))))
+      (wait-resize-images)
       (clean-resized-images))))
 
 (define (syntax-highlight xs)

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -318,7 +318,9 @@
                (map full-uri
                     (append (map post-uri-path (filter linked-post?
                                                        (hash-values new-posts)))
-                            non-post-pages))))))
+                            non-post-pages)))))
+  (when (current-responsive-images?)
+    (wait-resize-images)))
 
 ;;----------------------------------------------------------------------------
 


### PR DESCRIPTION
Yields a 2x speed-up on my dual-core i5 machine.

However, as it stands each size of an image to be resized yields a new subprocess potentially spawning many subprocesses concurrently if the site contains a lot of images (such as my own). This increases memory usage and may therefore cause disk swapping if memory is limited. Does not seem to be a big issue on my 8GB SSD-equipped machine but I understand performance characteristics may be different on other machines.

It may perhaps be preferable to a have a job server making sure that no more than N processes are spawned concurrently. A useful but potentially conservative value for N may be the number of processor cores.

OR perhaps I'm over-engineering here. WDYT?